### PR TITLE
Implement direct number input for Sudoku grid

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -81,10 +81,6 @@ class SudokuUI {
 
         this.selectedCell = { row, col };
         this.updateCellHighlights();
-        
-        if (this.selectedNumber) {
-            this.makeMove(row, col, this.selectedNumber);
-        }
     }
 
     selectNumber(number) {
@@ -284,7 +280,10 @@ class SudokuUI {
 
     handleKeyPress(event) {
         if (event.key >= '1' && event.key <= '9') {
-            this.selectNumber(parseInt(event.key));
+            const number = parseInt(event.key);
+            if (this.selectedCell) {
+                this.makeMove(this.selectedCell.row, this.selectedCell.col, number);
+            }
         } else if (event.key === 'Delete' || event.key === 'Backspace') {
             this.clearCell();
         } else if (event.key === 'Escape') {

--- a/styles.css
+++ b/styles.css
@@ -203,10 +203,7 @@ button {
 }
 
 .number-pad {
-    display: grid;
-    grid-template-columns: repeat(9, 1fr);
-    gap: 10px;
-    margin-bottom: 20px;
+    display: none;
 }
 
 .number-btn {


### PR DESCRIPTION
- Enable typing numbers 1-9 directly into selected cells
- Remove dependency on number pad selection for input
- Hide number pad interface for cleaner UI
- Improve keyboard user experience with immediate number placement